### PR TITLE
Add version def for war plugin and bump jar one to version in rhq-metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,32 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
-/.project
-/.settings/
+
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Intellij files# IDE files
+.project
+.classpath
+.settings
+.idea
+*.ipr
+*.iml
+*.iws
+nb-configuration.xml
+
+# KDE
+.directory
+
+# OS/X
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,8 @@
     <version.junit>4.11</version.junit>
     <version.org.apache.activemq>5.10.0</version.org.apache.activemq>
     <version.org.jboss.spec>1.0.0.Final</version.org.jboss.spec>
+    <version.org.jboss.logging>3.1.0.GA</version.org.jboss.logging>
+    <version.org.jboss.logging.processor>1.0.0.Final</version.org.jboss.logging.processor>
     <version.org.testng>6.5.2</version.org.testng>
     <version.org.wildfly>8.2.0.Final</version.org.wildfly>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,10 @@
     <plugin.version.org.apache.maven.plugins-maven-assembly-plugin>2.4</plugin.version.org.apache.maven.plugins-maven-assembly-plugin>
     <plugin.version.org.apache.maven.plugins-maven-compiler-plugin>2.5.1</plugin.version.org.apache.maven.plugins-maven-compiler-plugin>
     <plugin.version.org.apache.maven.plugins-maven-enforcer-plugin>1.3.1</plugin.version.org.apache.maven.plugins-maven-enforcer-plugin>
-    <plugin.version.org.apache.maven.plugins-maven-jar-plugin>2.4</plugin.version.org.apache.maven.plugins-maven-jar-plugin>
+    <plugin.version.org.apache.maven.plugins-maven-jar-plugin>2.5</plugin.version.org.apache.maven.plugins-maven-jar-plugin>
     <plugin.version.org.apache.maven.plugins-maven-release-plugin>2.5.1</plugin.version.org.apache.maven.plugins-maven-release-plugin>
     <plugin.version.org.apache.maven.plugins-maven-surefire-plugin>2.12.4</plugin.version.org.apache.maven.plugins-maven-surefire-plugin>
+    <plugin.version.org.apache.maven.plugins-maven-war-plugin>2.5</plugin.version.org.apache.maven.plugins-maven-war-plugin>
     <plugin.version.org.codehaus.mojo-exec-maven-plugin>1.3.1</plugin.version.org.codehaus.mojo-exec-maven-plugin>
 
     <!-- DEPENDENCY VERSIONS -->


### PR DESCRIPTION
Metrics uses version 2.5, so make jar one consistent.
Add new maven war plugin definition
