### PR TITLE
import WildFly BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,15 @@
         <scope>provided</scope>
       </dependency>
 
+      <!-- WildFly BOM - this also includes the org.jboss.spec:jboss-javaee-7.0 dependencies -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>jboss-javaee-7.0-with-all</artifactId>
+        <version>${version.org.wildfly}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Bus module has a need for wildfly dependencies (for things like Wildfly Module Extension code) and alerts needed log4j dependency which comes with this wildfly BOM as well. I'm sure other hawkular components will need wildfly dependencies, too, hence why I think we need this in parent POM.
