### PR TITLE
Adding a shared version for swagger annotations and the swagger mvn plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,18 @@
         Other kinds of scope (such as test and provided) do not belong here ar any circumstances.
         Ordering: alphabetic by version property
       -->
+      
+      <!-- Swagger REST annotations -->
+      <dependency>
+        <groupId>com.wordnik</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>${version.com.wordnik.swagger}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.wordnik</groupId>
+        <artifactId>swagger-core_2.10</artifactId>
+        <version>${version.com.wordnik.swagger}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         Naming convention: version.${artifactId} whenever unique enough; otherwise version.${groupId}.${artifactId}
         Ordering: alphabetic
     -->
+    <version.com.github.kongchen.swagger-maven-plugin>2.3.3</version.com.github.kongchen.swagger-maven-plugin>
     <version.com.mycila.license-maven-plugin>2.9</version.com.mycila.license-maven-plugin>
     <version.exec-maven-plugin>1.3.2</version.exec-maven-plugin>
     <version.maven-antrun-plugin>1.7</version.maven-antrun-plugin>
@@ -156,6 +157,7 @@
     -->
     <version.com.google.code.gson>2.2.4</version.com.google.code.gson>
     <version.com.google.guava>16.0.1</version.com.google.guava>
+    <version.com.wordnik.swagger>1.3.12</version.com.wordnik.swagger>
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.codehaus.groovy>2.3.8</version.org.codehaus.groovy>
     <version.org.codehaus.groovy.modules.http-builder>0.7</version.org.codehaus.groovy.modules.http-builder>
@@ -241,6 +243,12 @@
     <pluginManagement>
       <plugins>
         <!-- Ordering: alphabetic by the version property -->
+
+        <plugin>
+          <groupId>com.github.kongchen</groupId>
+          <artifactId>swagger-maven-plugin</artifactId>
+          <version>${version.com.github.kongchen.swagger-maven-plugin}</version>
+        </plugin>
 
         <plugin>
           <groupId>com.mycila</groupId>


### PR DESCRIPTION
In component {alerts|inventory|metrics} that contains a REST api, we generate the documentation from it based on the Swagger annotations. Let's sync the versions across the components, because they don't respect the sem-ver conventions and introduce breaking changes even with minor versions (when upgrading Swagger `1.2.3` -> `1.3.12`, code doesn't compile).

There are 2 artifacts using the `version.com.wordnik.swagger`:

``` xml
    <dependency>
      <groupId>com.wordnik</groupId>
      <artifactId>swagger-annotations</artifactId>
      <version>${version.com.wordnik.swagger}</version>
      <scope>provided</scope>
    </dependency>
    <dependency>
      <groupId>com.wordnik</groupId>
      <artifactId>swagger-core_2.10</artifactId>
      <version>${version.com.wordnik.swagger}</version>
    </dependency>
```

The above snippet is always part of the `docgen` profile that is not activated by default. The first dependency is provided (probably by the mvn plugin). I know, there is a convention to name the properties by "version."groupId.artifactId, but there are two artifact that will always have the same version, so I found redundant to keep both long properties, instead I used the longest prefix of the two artifacts.
