### PR TITLE
Upgrade of assembly plugin version 2.5.1 -> 2.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <version.com.mycila.license-maven-plugin>2.10</version.com.mycila.license-maven-plugin>
     <version.exec-maven-plugin>1.3.2</version.exec-maven-plugin>
     <version.maven-antrun-plugin>1.7</version.maven-antrun-plugin>
-    <version.maven-assembly-plugin>2.5.1</version.maven-assembly-plugin>
+    <version.maven-assembly-plugin>2.5.4</version.maven-assembly-plugin>
     <version.maven-checkstyle-plugin>2.13</version.maven-checkstyle-plugin>
     <version.maven-clean-plugin>2.6</version.maven-clean-plugin>
     <version.maven-compiler-plugin>3.2</version.maven-compiler-plugin>


### PR DESCRIPTION
Reason: I'm unable to unpack the war into directory when using 2.5.1. This is the error I'm getting:

> org.codehaus.plexus.archiver.ArchiverException: Problem writing to output in xAR operation request to write '734' bytes exceeds size in header of '412' bytes for entry 'hawkular-console.war/META-INF/MANIFEST.MF'
>         at org.codehaus.plexus.archiver.util.Streams.copyFullyDontCloseOutput(Streams.java:122)

and this seems to be related JIRA:
https://jira.codehaus.org/browse/MASSEMBLY-742
