### PR TITLE
add datastax driver for Cassandra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
       Naming convention: version.${groupId} whenever unique enough; otherwise version.${groupId}.${artifactId}
       Ordering: alphabetic
     -->
+    <version.com.datastax.cassandra>2.1.6</version.com.datastax.cassandra>
     <version.com.google.code.gson>2.2.4</version.com.google.code.gson>
     <version.com.google.guava>16.0.1</version.com.google.guava>
     <version.com.wordnik.swagger>1.3.12</version.com.wordnik.swagger>
@@ -187,6 +188,12 @@
         Other kinds of scope (such as test and provided) do not belong here ar any circumstances.
         Ordering: alphabetic by version property
       -->
+
+      <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-core</artifactId>
+        <version>${version.com.datastax.cassandra}</version>
+      </dependency>
 
       <!-- Swagger REST annotations -->
       <dependency>


### PR DESCRIPTION
I think it makes sense to put the Cassandra driver in the parent pom. We should all be running on the same versions of the driver and Cassandra.
