### PR TITLE
Mazz/wf9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,13 +171,21 @@
     <version.org.codehaus.groovy.modules.http-builder>0.7</version.org.codehaus.groovy.modules.http-builder>
     <version.junit>4.12</version.junit>
     <version.org.apache.activemq>5.10.0</version.org.apache.activemq>
+    <version.org.jboss.jboss-dmr>1.3.0.Final</version.org.jboss.jboss-dmr>
     <version.org.jboss.logging>3.1.0.GA</version.org.jboss.logging>
     <version.org.jboss.logging.jboss-logging-annotations>1.2.0.Final</version.org.jboss.logging.jboss-logging-annotations>
     <version.org.jboss.logging.jboss-logging-processor>1.2.0.Final</version.org.jboss.logging.jboss-logging-processor>
+    <version.org.jboss.msc>1.2.6.Final</version.org.jboss.msc>
     <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>
     <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
     <version.org.mockito>1.10.19</version.org.mockito>
     <version.org.testng>6.5.2</version.org.testng>
+
+    <!--
+      If you change wildfly versions, refer to the pom in org.wildfly.core:wildfly-core-parent to obtain
+      the proper versions for version.org.jboss.jboss-dmr and version.org.jboss.msc and others above since
+      those aren't in the BOM so we need to track them ourselves.
+    -->
     <version.org.wildfly>9.0.0.CR2</version.org.wildfly>
     <version.org.wildfly.core>1.0.0.CR6</version.org.wildfly.core>
   </properties>
@@ -226,6 +234,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-dmr</artifactId>
+        <version>${version.org.jboss.jboss-dmr}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>${version.org.jboss.logging}</version>
@@ -239,6 +253,12 @@
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-processor</artifactId>
         <version>${version.org.jboss.logging.jboss-logging-processor}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.msc</groupId>
+        <artifactId>jboss-msc</artifactId>
+        <version>${version.org.jboss.msc}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
I found there are two other things that aren't in the WF BOM that we need. Putting these up to parent pom will remind us to keep these tracking with the WildFly version as well. We are currently behind in our latest release of the agent because we are building with the older versions (I only just caught this today) but I don't think anything is breaking because of this. So I don't think we need to have an emergency release due to this. But we'll have to remember to keep these in sync with the wildfly version we are using.
