### PR TITLE
Revert "Add frontend-maven-plugin 0.0.24"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
     <version.com.github.kongchen.swagger-maven-plugin>2.3.3</version.com.github.kongchen.swagger-maven-plugin>
     <version.com.mycila.license-maven-plugin>2.10</version.com.mycila.license-maven-plugin>
     <version.exec-maven-plugin>1.3.2</version.exec-maven-plugin>
-    <version.frontend-maven-plugin>0.0.24</version.frontend-maven-plugin>
     <version.maven-antrun-plugin>1.7</version.maven-antrun-plugin>
     <version.maven-assembly-plugin>2.5.4</version.maven-assembly-plugin>
     <version.maven-checkstyle-plugin>2.15</version.maven-checkstyle-plugin>
@@ -313,12 +312,6 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${version.exec-maven-plugin}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>com.github.eirslett</groupId>
-          <artifactId>frontend-maven-plugin</artifactId>
-          <version>${version.frontend-maven-plugin}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This reverts commit 1e5ef1afc3da696c155d2814340ff0d60df6c3ba.

Adding frontend-maven-plugin 0.0.24 to the parent turned out not to be a good idea. On one hand the behavior has changed in 0.0.24, so that it would need an additional configuration to work properly and OTOH, the plugin is used in hawkular only, and therefore, there is no advantage in managing it here.

Sorry for this unnecessary complication. 
