### PR TITLE
Upgrade to Wildfly 9.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,8 @@
       the proper versions for version.org.jboss.jboss-dmr and version.org.jboss.msc and others above since
       those aren't in the BOM so we need to track them ourselves.
     -->
-    <version.org.wildfly>9.0.0.CR2</version.org.wildfly>
-    <version.org.wildfly.core>1.0.0.CR6</version.org.wildfly.core>
+    <version.org.wildfly>9.0.0.Final</version.org.wildfly>
+    <version.org.wildfly.core>1.0.0.Final</version.org.wildfly.core>
   </properties>
 
   <dependencyManagement>
@@ -286,7 +286,6 @@
         <artifactId>jboss-javaee-7.0-wildfly</artifactId>
         <version>${version.org.wildfly}</version>
         <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
     </dependencies>
@@ -483,6 +482,9 @@
           <groupId>org.wildfly.plugins</groupId>
           <artifactId>wildfly-maven-plugin</artifactId>
           <version>${version.wildfly-maven-plugin}</version>
+          <configuration>
+            <version>${version.org.wildfly}</version>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
As discussed in the mailing list:
- the Wildfly BOM is no longer forced on every project
- the Wildfly Maven plugin is configured to use our Wildfly version by
  default, instead of the default version specified in the Maven plugin
