### PR TITLE
Use slashstar style in Groovy files license header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,7 @@
             <g4>SLASHSTAR_STYLE</g4>
             <gradle>SLASHSTAR_STYLE</gradle>
             <gradlew>SCRIPT_STYLE</gradlew>
+            <groovy>SLASHSTAR_STYLE</groovy>
             <iql>DOUBLEDASHES_STYLE</iql>
             <jshintrc>SLASHSTAR_STYLE</jshintrc>
             <java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
With a proper IDE setup, it's easy to make license headers right so that running `mvn license:format` is rarely needed.

The remaining issue I have is with Groovy files. For some reason, the checker expect headers to be formatted as GroovyDoc by default. It should be simple doc `/*` (`SLASHSTAR_STYLE`). In fact, if you look at a [Groovy file](https://github.com/apache/incubator-groovy/blob/master/src/spec/test/SyntaxTest.groovy) in the Groovy project, they use this style.

Note that this change will require to run `mvn license:format` before pushing the commit to upgrade to parent 19, when it's released. 
