### PR TITLE
CSS license header should use slash star style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,6 +554,7 @@
           <mapping>
             <conf>SCRIPT_STYLE</conf>
             <cql>DOUBLEDASHES_STYLE</cql>
+            <css>SLASHSTAR_STYLE</css>
             <Dockerfile>SCRIPT_STYLE</Dockerfile>
             <drl>SLASHSTAR_STYLE</drl>
             <editorconfig>SCRIPT_STYLE</editorconfig>


### PR DESCRIPTION
I'm not sure double star even means something in CSS
