### PR TITLE
Enforcing the format of the project version to end with a "digit", "-SNAPSHOT" or ".Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -887,8 +887,8 @@
               <!-- stronger version of https://developer.jboss.org/wiki/JBossProjectVersioning -->
               <property>project.version</property>
               <message>Project version must be specified.</message>
-              <regex>^(\d{1,4}(-SNAPSHOT)?|\d{1,3}\.\d{1,3}\.\d{1,3}(-SNAPSHOT|\.Alpha\d|\.Beta\d|\.CR\d|\.Final))$</regex>
-              <regexMessage>Project version must be in the form of one of the following (x,y,z stands for any numbers, N for a digit): x, x-SNAPSHOT, x.y.z-SNAPSHOT, x.y.z.AlphaN, x.y.z.BetaN, x.y.z.CRN, or x.y.z.Final</regexMessage>
+              <regex>^(\d{1,4})(\.\d{1,3})?(\.\d{1,3})?(\.Alpha\d{1,2}|\.Beta\d{1,2}|\.CR\d{1,2}|\.Final)?(-SNAPSHOT|-SRC-.*)?$</regex>
+              <regexMessage>Project version must be in the form of one of the following (x,y,z stands for any numbers): "x", "x.y", "x.y.z".There may be also a qualifier at the end. Qualifier can be one of the following: ".AlphaX", ".BetaX", ".CRX", ".Final", where X denotes a number. And there may be also "-SNAPSHOT" at the very end.</regexMessage>
             </requireProperty>
           </rules>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -883,6 +883,12 @@
             </requireJavaVersion>
             <requireNoRepositories />
             <requirePluginVersions />
+            <requireProperty>
+              <property>project.version</property>
+              <message>"Project version must be specified."</message>
+              <regex>.*(\d|-SNAPSHOT|\.Final)$</regex>
+              <regexMessage>"Project version must end in a number, -SNAPSHOT or .Final"</regexMessage>
+            </requireProperty>
           </rules>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -884,10 +884,11 @@
             <requireNoRepositories />
             <requirePluginVersions />
             <requireProperty>
+              <!-- stronger version of https://developer.jboss.org/wiki/JBossProjectVersioning -->
               <property>project.version</property>
-              <message>"Project version must be specified."</message>
-              <regex>.*(\d|-SNAPSHOT|\.Final)$</regex>
-              <regexMessage>"Project version must end in a number, -SNAPSHOT or .Final"</regexMessage>
+              <message>Project version must be specified.</message>
+              <regex>^(\d{1,4}(-SNAPSHOT)?|\d{1,3}\.\d{1,3}\.\d{1,3}(-SNAPSHOT|\.Alpha\d|\.Beta\d|\.CR\d|\.Final))$</regex>
+              <regexMessage>Project version must be in the form of one of the following (x,y,z stands for any numbers, N for a digit): x, x-SNAPSHOT, x.y.z-SNAPSHOT, x.y.z.AlphaN, x.y.z.BetaN, x.y.z.CRN, or x.y.z.Final</regexMessage>
             </requireProperty>
           </rules>
         </configuration>


### PR DESCRIPTION
In the release plugin interactive mode, it's easy to make a mistake and release version called x.y.z-Final, instead of x.y.z.Final. This rule shouldn't allow that.

~~Note: the rule for digit is here only for the parent pom itself.. other option would be to remove this rule and make the parent pom to version itself under x-SNAPSHOT and x.Final.~~
