### PR TITLE
Exclude *.bundle.js from checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
       release.properties,
       **/*.d.ts,
       **/vendor/*.js,
+      **/*.bundle.js,
     </hawkular.checkstyle.excludes>
     <!-- the default value pointing at suppressions.xml in hawkular-build-tools -->
     <checkstyle.suppressions.file>hawkular-checkstyle/suppressions.xml</checkstyle.suppressions.file>


### PR DESCRIPTION
This commit is needed for UI developments. Angular 2+ generates this kind of files, which don't pass checkstyle.